### PR TITLE
Handle changes to reason types in webpack 5

### DIFF
--- a/src/getModuleGraphWithReasons.ts
+++ b/src/getModuleGraphWithReasons.ts
@@ -127,7 +127,7 @@ export function getModuleGraphWithReasons(
         );
 
         sortedReasons.forEach((reason: WebpackStats.Reason): void => {
-            if (reason.type == 'multi entry' || reason.type == 'single entry') {
+            if (!reason.type || (reason.type as any) == 'entry' || reason.type == 'multi entry' || reason.type == 'single entry') {
                 return;
             }
 


### PR DESCRIPTION
Webpack 5 changed the `type` property for modules such that it is now just `'entry'` for entries, and `undefined` for webpack runtime modules. 

This change updates the code to handle these changes.