### PR TITLE
Handle entry module reasons added in webpack 5

### DIFF
--- a/src/getModuleGraphWithReasons.ts
+++ b/src/getModuleGraphWithReasons.ts
@@ -133,11 +133,14 @@ export function getModuleGraphWithReasons(
                 // recognize.
                 //
                 // (In tests this triggers on style loader chains of preprocessed css)
-                reason.type &&
-                // Handle webpack updating underneath types.
-                ((reason.type as any) == 'entry' ||
-                    reason.type == 'multi entry' ||
-                    reason.type == 'single entry')
+                (reason.type &&
+                    // Handle webpack updating underneath types.
+                    ((reason.type as any) == 'entry' ||
+                        reason.type == 'multi entry' ||
+                        reason.type == 'single entry')) ||
+                // Entry modules get a reason that says it's used as a library export, with no moduleName or other information
+                // https://github.com/webpack/webpack/blob/547b4d8deb75355bf5695349fdcc3830ec22d68f/lib/library/ExportPropertyLibraryPlugin.js#L86
+                reason.explanation === 'used as library export'
             ) {
                 return;
             }


### PR DESCRIPTION
Webpack v5, when building library entries, adds a reason to the entry modules of the form:
```json
{
  "moduleIdentifier": null,
  "module": null,
  "moduleName": null,
  "resolvedModuleIdentifier": null,
  "resolvedModule": null,
  "type": null,
  "active": true,
  "explanation": "used as library export",
  "userRequest": null,
  "moduleId": null,
  "resolvedModuleId": null
}
```

Since this has no `moduleName`, it was tripping the logic that threw an exception. Instead, we should ignore it like we do for reasons with `type` of `'entry'`